### PR TITLE
Refactor/99 fix images distortion

### DIFF
--- a/src/components/nc-card-item.vue
+++ b/src/components/nc-card-item.vue
@@ -127,10 +127,18 @@ export default {
   text-align: left;
   display: flex;
   flex-direction: column;
+
   &__image {
     position: relative;
+
     .image-content {
+      height: 100%;
       width: 100%;
+      object-fit: cover;
+
+      @media all and (-ms-high-contrast: none) {
+        width: auto;
+      }
     }
   }
   &__content {

--- a/src/components/nc-slideshow.vue
+++ b/src/components/nc-slideshow.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="nc-slideshow">
     <div class="nc-slideshow__content" :style="{'width': `${width}px`}">
-      <ul class="list" 
+      <ul class="nc-slideshow__list"
         v-touch:swipe.right="previousSlide"
         v-touch:swipe.left="nextSlide"
         :style="{
@@ -9,6 +9,10 @@
           transform: `translate3d(-${slideIndex * width}px, 0, 0)`,
           transition: 'transform 500ms ease'
         }">
+        <li v-for="(imgSrc, index) in images"
+            class="nc-slideshow__item">
+          <img :src="imgSrc" :alt="" class="nc-slideshow__image"/>
+        </li>
         <slot></slot>
       </ul>
     </div>
@@ -99,6 +103,10 @@ export default {
           ariaTextDots: 'Slide'
         }
       }
+    },
+    images: {
+      type: Array,
+      default: []
     }
   },
   data() {

--- a/src/components/nc-slideshow.vue
+++ b/src/components/nc-slideshow.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="nc-slideshow">
     <div class="nc-slideshow__content" :style="{'width': `${width}px`}">
-      <ul class="nc-slideshow__list"
+      <ul class="list"
         v-touch:swipe.right="previousSlide"
         v-touch:swipe.left="nextSlide"
         :style="{
@@ -9,22 +9,27 @@
           transform: `translate3d(-${slideIndex * width}px, 0, 0)`,
           transition: 'transform 500ms ease'
         }">
-        <li v-for="(imgSrc, index) in images"
-            class="nc-slideshow__item">
-          <img :src="imgSrc" :alt="" class="nc-slideshow__image"/>
-        </li>
-        <slot></slot>
+        <template v-if="images.length">
+          <li v-for="(image, index) in images" :key="index" class="list__item">
+            <img class="image" :src="image" @error="setDefaultImage">
+          </li>
+        </template>
+        <template v-else>
+          <li class="item">
+            <div class="list__image" :style="{ 'background-image': `url(${defaultImage})` }"/>
+          </li>
+        </template>
       </ul>
     </div>
     <div class="nc-slideshow__pagination">
       <ul class="dots" aria-label="Pagination Slideshow" role="navigation">
-        <li 
-          :style="paginationStyle" 
-          v-for="(i, index) in slideLength" 
+        <li
+          :style="paginationStyle"
+          v-for="(i, index) in slideLength"
           :key=index
         >
-          <button 
-            @click.stop="selectSlide(index)" 
+          <button
+            @click.stop="selectSlide(index)"
             :class="[ slideIndex === index ? paginationActiveClass : '', 'dots__button']"
           >
             <span class="dots__text">{{ ariaText.ariaTextDots + index + 1 }}</span>
@@ -32,20 +37,20 @@
         </li>
       </ul>
     </div>
-    <button 
-      v-if="hasLinkLeft" 
-      class="nc-slideshow__link--left" 
-      @click="leftLinkHandler($event)" 
+    <button
+      v-if="hasLinkLeft"
+      class="nc-slideshow__link--left"
+      @click="leftLinkHandler($event)"
       :data-slide-to="slideIndex + 1"
       :style="leftLinkStyle"
       role="button"
     >
       {{ leftLinkText }}
     </button>
-    <button 
-      v-if="hasLinkRight" 
+    <button
+      v-if="hasLinkRight"
       class="nc-slideshow__link--right"
-      @click="rightLinkHandler($event)" 
+      @click="rightLinkHandler($event)"
       :data-slide-to="slideIndex + 1"
       :style="rightLinkStyle"
       role="button"
@@ -53,7 +58,7 @@
       {{ rightLinkText }}
     </button>
   </div>
-  
+
 </template>
 
 <script>
@@ -106,8 +111,9 @@ export default {
     },
     images: {
       type: Array,
-      default: []
-    }
+      default: () => []
+    },
+    defaultImage: String
   },
   data() {
     return {
@@ -164,6 +170,9 @@ export default {
       this.slideList.forEach(element => {
         element.style.width = this.width + 'px'
       })
+    },
+    setDefaultImage(ev) {
+      ev.target.src = this.defaultImage
     }
   },
   mounted() {
@@ -193,7 +202,7 @@ $dotBackgrounColorActive: #ff7f3f;
     display: block;
     margin: 0;
     padding: 0;
-    height: calc(100% - 20px);
+    height: 100%;
     .list {
       height: 100%;
       position: relative;
@@ -204,11 +213,19 @@ $dotBackgrounColorActive: #ff7f3f;
       margin: 0;
       padding: 0;
 
-      .item {
+      &__item {
         float: left;
         height: 100%;
         min-height: 1px;
-        display: block;
+        .image {
+          height: 100%;
+          width: 100%;
+          object-fit: cover;
+          display: block;
+          @media all and (-ms-high-contrast: none) {
+            width: auto;
+          }
+        }
       }
     }
   }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -103,17 +103,12 @@
         :has-link-right="true"
         :has-link-left="true"
         :links-default-action="true"
+        :images="['http://via.placeholder.com/640x360', 'http://via.placeholder.com/640x560', 'http://via.placeholder.com/800x360']"
         @slideshow-click-left-link="clickSlideshowLinkLeft"
         @slideshow-click-right-link="clickSlideshowLinkRight"
         @slideshow-last-slide="lastSlide"
         @slideshow-first-slide="firstSlide"
-      >
-        <template>
-          <li class="item">SLIDE 1</li>
-          <li class="item">SLIDE 2</li>
-          <li class="item">SLIDE 3</li>
-        </template>
-      </nc-slideshow>
+      />
     </div>
     <hr>
     <br>
@@ -340,16 +335,16 @@ export default {
         iso: 'ES'
       },
       ncPhoneInputLabel: 'Teléfono de contacto',
-      maxDistance: 150,
-      maxDistanceLimit: 150,
+      maxDistance: '150',
+      maxDistanceLimit: '150',
       minPrice: '0',
-      maxPrice: 1000,
-      minPercentage: 15,
-      maxPercentage: 100,
+      maxPrice: '1000',
+      minPercentage: '15',
+      maxPercentage: '100',
       minPriceLimit: '0',
-      maxPriceLimit: 1000,
-      minPercentageLimit: 15,
-      maxPercentageLimit: 100
+      maxPriceLimit: '1000',
+      minPercentageLimit: '15',
+      maxPercentageLimit: '100'
     }
   },
   methods: {

--- a/tests/unit/fixtures/nc-slideshow.fixture.js
+++ b/tests/unit/fixtures/nc-slideshow.fixture.js
@@ -1,0 +1,48 @@
+export const defaultProps = {
+  paginationActiveClass: 'active',
+  paginationStyle: undefined,
+  hasLinkLeft: false,
+  hasLinkRight: false,
+  leftLinkText: 'Previous',
+  rightLinkText: 'Next',
+  linksDefaultAction: false,
+  leftLinkStyle: undefined,
+  rightLinkStyle: undefined,
+  ariaText: { ariaTextDots: 'Slide' },
+  defaultImage: undefined,
+  images: []
+}
+
+export const propsWithButtons = {
+  paginationActiveClass: 'active',
+  paginationStyle: undefined,
+  hasLinkLeft: true,
+  hasLinkRight: true,
+  leftLinkText: 'Previous',
+  rightLinkText: 'Next',
+  linksDefaultAction: true,
+  leftLinkStyle: undefined,
+  rightLinkStyle: undefined,
+  ariaText: { ariaTextDots: 'Slide' },
+  defaultImage: undefined,
+  images: []
+}
+
+export const propsWithImages = {
+  paginationActiveClass: 'active',
+  paginationStyle: undefined,
+  hasLinkLeft: true,
+  hasLinkRight: true,
+  leftLinkText: 'Previous',
+  rightLinkText: 'Next',
+  linksDefaultAction: true,
+  leftLinkStyle: undefined,
+  rightLinkStyle: undefined,
+  ariaText: { ariaTextDots: 'Slide' },
+  defaultImage: undefined,
+  images: [
+    'http://via.placeholder.com/640x360',
+    'http://via.placeholder.com/640x360',
+    'http://via.placeholder.com/640x360'
+  ]
+}

--- a/tests/unit/nc-slideshow.spec.js
+++ b/tests/unit/nc-slideshow.spec.js
@@ -1,23 +1,16 @@
 /* eslint-disable no-debugger */
 import { createLocalVue, mount } from '@vue/test-utils'
 import ncSlideshow from '@/components/nc-slideshow.vue'
+import {
+  defaultProps,
+  propsWithImages,
+  propsWithButtons
+} from './fixtures/nc-slideshow.fixture'
 import Vue2TouchEvents from 'vue2-touch-events'
 const localVue = createLocalVue()
 localVue.use(Vue2TouchEvents)
 
 describe('ncSlideshow', () => {
-  const defaultProps = {
-    paginationActiveClass: 'active',
-    paginationStyle: undefined,
-    hasLinkLeft: false,
-    hasLinkRight: false,
-    leftLinkText: 'Previous',
-    rightLinkText: 'Next',
-    linksDefaultAction: false,
-    leftLinkStyle: undefined,
-    rightLinkStyle: undefined,
-    ariaText: { ariaTextDots: 'Slide' }
-  }
   describe('when mounted without props', () => {
     let wrapper
     let result
@@ -38,22 +31,58 @@ describe('ncSlideshow', () => {
     })
   })
 
-  describe('when mounted slot', () => {
+  describe('with a list of images', () => {
     let wrapper
 
     beforeAll(() => {
       wrapper = mount(ncSlideshow, {
         attachToDocument: true,
         localVue,
-        slots: {
-          default:
-            '<li class="item">SLIDE 1</li><li class="item">SLIDE 2</li><li class="item">SLIDE 3</li>'
-        }
+        propsData: propsWithImages
       })
     })
 
     it('should have the prop slideLength with the same value as the number of li', () => {
       expect(wrapper.vm.slideLength).toBe(3)
+    })
+  })
+
+  describe('.rightLinkHandler', () => {
+    describe('when right link is clicked and the last slide is displayed', () => {
+      let wrapper
+      const slideIndex = 2
+      beforeAll(() => {
+        wrapper = mount(ncSlideshow, {
+          localVue,
+          propsData: propsWithButtons
+        })
+        wrapper.setData({ slideIndex: slideIndex })
+        wrapper.vm.rightLinkHandler()
+      })
+      it('should keep the same slideIndex', () => {
+        expect(wrapper.vm.slideIndex).toBe(slideIndex)
+      })
+      it('slideshow-last-slide is emitted', () => {
+        expect(wrapper.emitted('slideshow-last-slide')).toBeTruthy()
+      })
+    })
+
+    describe('when right link is clicked first time', () => {
+      let wrapper
+      beforeAll(() => {
+        wrapper = mount(ncSlideshow, {
+          localVue,
+          propsData: propsWithButtons,
+          attachToDocument: true
+        })
+        wrapper.vm.rightLinkHandler()
+      })
+      it('should increase slideIndex', () => {
+        expect(wrapper.vm.slideIndex).toBe(1)
+      })
+      it('the event slideshow-click-right-link is emitted', () => {
+        expect(wrapper.emitted('slideshow-click-right-link')).toBeTruthy()
+      })
     })
   })
 
@@ -63,7 +92,6 @@ describe('ncSlideshow', () => {
       let wrapper
       beforeAll(() => {
         wrapper = mount(ncSlideshow, {
-          attachToDocument: true,
           localVue,
           propsData: defaultProps
         })
@@ -90,108 +118,17 @@ describe('ncSlideshow', () => {
     })
   })
 
-  describe('.rightLinkHandler', () => {
-    const defaultProps = {
-      paginationActiveClass: 'active',
-      paginationStyle: undefined,
-      hasLinkLeft: false,
-      hasLinkRight: true,
-      leftLinkText: 'Previous',
-      rightLinkText: 'Next',
-      linksDefaultAction: true,
-      leftLinkStyle: undefined,
-      rightLinkStyle: undefined,
-      ariaText: { ariaTextDots: 'Slide' }
-    }
-    describe('when right link is clicked', () => {
-      let wrapper
-      beforeAll(() => {
-        wrapper = mount(ncSlideshow, {
-          localVue,
-          propsData: defaultProps
-        })
-      })
-      it('should be called', () => {
-        let stub = jest.fn()
-        wrapper.setMethods({ rightLinkHandler: stub })
-        wrapper.find('.nc-slideshow__link--right').trigger('click')
-        expect(stub).toBeCalled()
-      })
-    })
-    describe('when right link is clicked first time', () => {
-      let wrapper
-      beforeAll(() => {
-        wrapper = mount(ncSlideshow, {
-          localVue,
-          propsData: defaultProps
-        })
-        wrapper.find('.nc-slideshow__link--right').trigger('click')
-      })
-      it('should increase slideIndex', () => {
-        expect(wrapper.vm.slideIndex).toBe(1)
-      })
-      it('the event slideshow-click-right-link is emitted', () => {
-        expect(wrapper.emitted('slideshow-click-right-link')).toBeTruthy()
-      })
-    })
-    describe('when right link is clicked and the last slide is displayed', () => {
-      let wrapper
-      const slideIndex = 2
-      beforeAll(() => {
-        wrapper = mount(ncSlideshow, {
-          localVue,
-          propsData: defaultProps
-        })
-        wrapper.setData({ slideIndex: slideIndex })
-        wrapper.find('.nc-slideshow__link--right').trigger('click')
-      })
-      it('should keep the same slideIndex', () => {
-        expect(wrapper.vm.slideIndex).toBe(slideIndex)
-      })
-      it('slideshow-last-slide is emitted', () => {
-        expect(wrapper.emitted('slideshow-last-slide')).toBeTruthy()
-      })
-    })
-  })
-
   describe('.leftLinkHandler', () => {
-    const defaultProps = {
-      paginationActiveClass: 'active',
-      paginationStyle: undefined,
-      hasLinkLeft: true,
-      hasLinkRight: false,
-      leftLinkText: 'Previous',
-      rightLinkText: 'Next',
-      linksDefaultAction: true,
-      leftLinkStyle: undefined,
-      rightLinkStyle: undefined,
-      ariaText: { ariaTextDots: 'Slide' }
-    }
-    describe('when left link is clicked', () => {
-      let wrapper
-      beforeAll(() => {
-        wrapper = mount(ncSlideshow, {
-          localVue,
-          propsData: defaultProps
-        })
-      })
-      it('should be called', () => {
-        let stub = jest.fn()
-        wrapper.setMethods({ leftLinkHandler: stub })
-        wrapper.find('.nc-slideshow__link--left').trigger('click')
-        expect(stub).toBeCalled()
-      })
-    })
     describe('when left link is clicked first time', () => {
       let wrapper
       const slideIndex = 2
       beforeAll(() => {
         wrapper = mount(ncSlideshow, {
           localVue,
-          propsData: defaultProps
+          propsData: propsWithButtons
         })
         wrapper.setData({ slideIndex: slideIndex })
-        wrapper.find('.nc-slideshow__link--left').trigger('click')
+        wrapper.vm.leftLinkHandler()
       })
       it('should increase slideIndex', () => {
         expect(wrapper.vm.slideIndex).toBe(1)
@@ -206,10 +143,10 @@ describe('ncSlideshow', () => {
       beforeAll(() => {
         wrapper = mount(ncSlideshow, {
           localVue,
-          propsData: defaultProps
+          propsData: propsWithButtons
         })
         wrapper.setData({ slideIndex: slideIndex })
-        wrapper.find('.nc-slideshow__link--left').trigger('click')
+        wrapper.vm.leftLinkHandler()
       })
       it('should keep the same slideIndex', () => {
         expect(wrapper.vm.slideIndex).toBe(slideIndex)


### PR DESCRIPTION
#99 
- nc-card-item add "object-fit: cover" to fix image size without distortion
- nc-slideshow modify component. First iteration. Now the list is inside the component and it receives an images array to display it. Fix styles to avoid image distortion