### PR TITLE
Bugfix/965- Edit product number in iPhone

### DIFF
--- a/src/components/nc-text-input.vue
+++ b/src/components/nc-text-input.vue
@@ -303,6 +303,7 @@ $errorColor: red;
         background: none;
         font-size: 17px;
         z-index: 1;
+        transform: translateZ(0);
         &:focus {
           outline: 0;
         }


### PR DESCRIPTION
This PR fixes bug https://github.com/NextChance/maia/issues/965

- Input values are set correctly in iOS