### PR TITLE
Bugfix/1189-Product form: enter key

### DIFF
--- a/src/components/nc-text-input.vue
+++ b/src/components/nc-text-input.vue
@@ -37,6 +37,7 @@
         :required="required"
         :size="size"
         :type="inputType"
+        :step="stepNumber"
         :value="value"
         @input="handleInput"
         @keyup="handleKeyUp"
@@ -153,6 +154,9 @@ export default {
     size: {
       type: Number,
       default: 35
+    },
+    stepNumber: {
+      default: 1
     },
     uiReference: {
       type: String,


### PR DESCRIPTION
New property to set if an input of type number accepts decimal numbers (set stepNumber to `any`)

⚠️ Increase version and tag after PR is merged.