### PR TITLE
Eliminates styles in line for the component and add a class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -->
 
 
+
+## [UNRELEASED]
+
+### Changed
+- nc-card-item, eliminates styles in line for component in use.
+
 ## v0.1.11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-## [UNRELEASED]
+## v0.2.0
 
 ### Changed
 - nc-card-item, eliminates styles in line for component in use.

--- a/src/components/nc-card-item.vue
+++ b/src/components/nc-card-item.vue
@@ -62,6 +62,10 @@ export default {
       type: String,
       default: 'Caption'
     },
+    contentStyle: {
+      type: String,
+      default: ''
+    },
     description: {
       type: String,
       default: 'Description'

--- a/src/components/nc-card-item.vue
+++ b/src/components/nc-card-item.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="['nc-card-item', wrapperClass]">
-    <div 
+    <div
       class="clickable"
       @click="handleCardItemClicked($event)"
       :ref="cardItemReference"
@@ -14,8 +14,7 @@
           :style="imageStyle"
           @error="handleImageError">
         <div
-          :class="caption"
-          :style="captionStyle"
+          class="nc_card-item__caption"
           v-if="caption"
         >
           {{ caption }}
@@ -62,11 +61,6 @@ export default {
     caption: {
       type: String,
       default: 'Caption'
-    },
-    captionStyle: Object,
-    contentStyle: {
-      type: String,
-      default: ''
     },
     description: {
       type: String,

--- a/src/components/nc-card-item.vue
+++ b/src/components/nc-card-item.vue
@@ -14,7 +14,7 @@
           :style="imageStyle"
           @error="handleImageError">
         <div
-          class="nc_card-item__caption"
+          class="nc-card-item__caption"
           v-if="caption"
         >
           {{ caption }}

--- a/tests/unit/fixtures/nc-card-item.fixture.js
+++ b/tests/unit/fixtures/nc-card-item.fixture.js
@@ -1,8 +1,6 @@
 export const defaultProps = {
   cardItemReference: 'cardItemRef',
   caption: 'Caption',
-  captionStyle: undefined,
-  contentStyle: '',
   extraContentStyle: undefined,
   description: 'Description',
   descriptionLineEllipsis: 3,


### PR DESCRIPTION
### Eliminates 

- In line styles for the nc-card-item component. Add a class to apply styles in the nc-card-item caption div where been used.