### PR TITLE
Bugfix/bh 517 remove default background on image uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 ### Security
 -->
+## v1.5.0
+### Fixed
+- Remove double background on ncImageLoader to not show it on transparent uploads.
+### Changed
+- ncPhoneInput now sends formatted phone without spaces. When we introduce a valid phone number (including dashed, spaced or split with dash bars) the result will be the same.
+
 ## v1.4.0
 ### Changed
 - ncCardItem new slot inside subheader

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui-components",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/nc-image-uploader.vue
+++ b/src/components/nc-image-uploader.vue
@@ -16,7 +16,7 @@
         :class="['nc-image-uploader_background','nc-uploader_label', hasError ? 'error' : '']"
         :style="{
           borderRadius: radius,
-          backgroundImage: `url(${bgImage}), url(${bgImage != '' ? defaultBackground : ''})`
+          backgroundImage: bgImage ? `url(${bgImage})` : `url('')`
         }"
         >
             <figure v-if="isEmpty"

--- a/src/components/nc-phone-input.vue
+++ b/src/components/nc-phone-input.vue
@@ -163,7 +163,7 @@ export default {
         return ''
       }
       if (this.formattingDisabled) {
-        return Array.prototype.filter.call(this.phone, char => char !== ' ' && char !== '.').join('')
+        return this.phone
       }
       let phone = this.phone
       if (this.displayMode === 'code') {
@@ -175,11 +175,15 @@ export default {
         // Ex: 0432421999
         phone = this.phone.slice(1)
       }
-      return formatNumber(
+      const _formattedResult =  formatNumber(
         phone,
         this.selectedCountry && this.selectedCountry.iso.toUpperCase(),
         this.format[0]
       )
+      const _removeSpaces = phoneNumber => {
+        return Array.prototype.filter.call(phoneNumber, char => char !== ' ').join('')
+      }
+      return _removeSpaces(_formattedResult)
     },
     isValid() {
       return isValidNumber(

--- a/src/components/nc-phone-input.vue
+++ b/src/components/nc-phone-input.vue
@@ -162,6 +162,9 @@ export default {
       if (!this.displayMode) {
         return ''
       }
+      if (this.formattingDisabled) {
+        return Array.prototype.filter.call(this.phone, char => char !== ' ' && char !== '.').join('')
+      }
       let phone = this.phone
       if (this.displayMode === 'code') {
         // If user manually type the country code
@@ -171,9 +174,6 @@ export default {
         // Remove the first '0' if this is a '0' prefix number
         // Ex: 0432421999
         phone = this.phone.slice(1)
-      }
-      if (this.formattingDisabled) {
-        return this.phone
       }
       return formatNumber(
         phone,


### PR DESCRIPTION
[BH-511](https://nextchance.atlassian.net/browse/BH-511)
[BH-517](https://nextchance.atlassian.net/browse/BH-517)

- Remove double background on ncImageLoader to not show it on transparent uploads.
- ncPhoneInput now sends formatted phone without spaces. When we introduce a valid phone number (including dashed, spaced or split with dash bars) the result will be the same.