### PR TITLE
Feature/nc card item image as slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 -->
 
+## v1.9.0
+### Changed
+- nc-card-item allows image as slot keeping the default one if slot is not passed
+
 ## v1.8.3
 ### Changed
 - nc-text-input will not trim always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 -->
 
+## v1.9.1
+### Fixed
+- nc-card-item draws an image if image slot is not present and component has image property
+
 ## v1.9.0
 ### Changed
 - nc-card-item allows image as slot keeping the default one if slot is not passed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui-components",
-  "version": "1.8.3",
+  "version": "1.9.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui-components",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/nc-card-item.vue
+++ b/src/components/nc-card-item.vue
@@ -7,7 +7,7 @@
     >
       <div class="nc-card-item__image">
         <slot v-if="$slots['image']" name="image" />
-        <img v-else="image"
+        <img v-else-if="image"
           alt="imageAlt"
           class="nc-card-item__image__content"
           :src="image"

--- a/src/components/nc-card-item.vue
+++ b/src/components/nc-card-item.vue
@@ -6,8 +6,8 @@
       :ref="cardItemReference"
     >
       <div class="nc-card-item__image">
-        <img
-          v-if="image"
+        <slot v-if="$slots['image']" name="image" />
+        <img v-else="image"
           alt="imageAlt"
           class="nc-card-item__image__content"
           :src="image"


### PR DESCRIPTION
As we saw yesterday, the nc-card-item component is updated to allow an image slot to allow us do lazy loading images from maia where this component is used.

If slot is not present, a default img is shown.