### PR TITLE
bugfix/BH-4864

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 -->
 
+
+## [UNRELEASED]
+### Fixed
+- Fix height for placeholder on nc-slideshow when images.length === 0 [BH-4864]
+
 ## v1.15.2
 ### Added
 - New property in nc-slideshow "srcSets" [BH-4795]

--- a/src/components/nc-slideshow.vue
+++ b/src/components/nc-slideshow.vue
@@ -15,8 +15,7 @@
           </li>
         </template>
         <template v-else>
-          <li class="item">
-            <div class="list__image" :style="{ 'background-image': `url(${defaultImage})` }"/>
+          <li class="list__item list__item--placeholder" :style="{ 'background-image': `url(${defaultImage})` }">
           </li>
         </template>
       </ul>
@@ -231,6 +230,11 @@
           min-height: 1px;
           display: flex;
           align-items: center;
+          &--placeholder {
+            width: 100%;
+            height: 100%;
+            background-size: cover;
+          }
 
           .image {
             display: block;


### PR DESCRIPTION
- fix placeholder size on nc-slideshow
Related with -> https://nextchance.atlassian.net/browse/BH-4864
It should tagged when maia 1.32.1 is in production