### PR TITLE
Release/next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 -->
 
-## [UNRELEASED]
+## v1.16.0
 ### Changed
 - nc-slideshow-v2: reduce size dots and updated dots behaviour (now navigation using dots is optional) [BH-4809]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 -->
 
+## [UNRELEASED]
+### Changed
+- nc-slideshow-v2: reduce size dots and updated dots behaviour (now navigation using dots is optional) [BH-4809]
+### Added
+- Add viewability mixin in 'nc-carousel', 'nc-featured-detail', 'nc-product-detail', 'nc-featured-grid' and 'nc-slideshow-v2'. Add method to emit event [BH-4948]
+
 ## v1.15.4
 ### Fixed
 - Fix border-radius in nc-slideshow-v2 for iOS: Add transform:translateX(0) [BH-4955]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui-components",
-  "version": "1.16.0",
+  "version": "1.15.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui-components",
-  "version": "1.15.4",
+  "version": "1.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui-components",
-  "version": "1.15.4",
+  "version": "1.16.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-ui-components",
-  "version": "1.16.0",
+  "version": "1.15.4",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
## v1.16.0
### Changed
- nc-slideshow-v2: reduce size dots and updated dots behaviour (now navigation using dots is optional) [BH-4809]
### Added
- Add viewability mixin in 'nc-carousel', 'nc-featured-detail', 'nc-product-detail', 'nc-featured-grid' and 'nc-slideshow-v2'. Add method to emit event [BH-4948]


[BH-4809]: https://nextchance.atlassian.net/browse/BH-4809
[BH-4948]: https://nextchance.atlassian.net/browse/BH-4948