### PR TITLE
bugfix/BH-5766 ncSlideshow lazy load

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,6 @@
 <head>
     <script src="https://unpkg.com/vue-lazyload/vue-lazyload.js"></script>
+    <script src="https://unpkg.com/vue-observe-visibility/dist/vue-observe-visibility.min.js"></script>
+    <script src="path/to/vue-touch-events.js"></script>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
 </head>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,11 +3,15 @@ import { addParameters } from '@storybook/client-api';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import Vue from 'vue'
 import VueLazyload from 'vue-lazyload'
+import Vue2TouchEvents from 'vue2-touch-events'
+ 
+Vue.use(Vue2TouchEvents)
 Vue.use(VueLazyload, {
   lazyComponent: true,
   preLoad: 2,
   attempt: 1
 })
+Vue.use(VueObserveVisibility)
 
 addParameters({
     viewport: {

--- a/src/components/nc-slideshow-v2.vue
+++ b/src/components/nc-slideshow-v2.vue
@@ -9,13 +9,11 @@
       <template>
         <li v-observe-visibility="viewabilityConfig" @viewability-done="handleImpression(item)" v-for="(item, index) in virtualImages" :key="index" class="nc-slideshow__content__item">
           <a :href="item.url" :target="item.isExternalUrl ? '_blank': '_self'" @click="handleClick($event, item.url, index+1, item.id)">
-            <nc-lazy-image 
-              :src="item.image" 
+            <img
+              :src="item.image"
               :alt="item.alt"
-              :placeholder="placeholderImage" 
-              :error="errorImage" 
-              :srcSets="srcSets"
-            />
+              @error="setErrorImage"
+            >
           </a>
         </li>
       </template>
@@ -56,14 +54,10 @@
 
 <script>
 import viewabilityMixin from '../../mixins/viewabilityMixin'
-import NcLazyImage from './nc-lazy-image'
 
 export default {
   name: 'nc-slideshow-v2',
   mixins: [viewabilityMixin],
-  components: {
-    NcLazyImage
-  },
   props: {
     images: {
       type: Array,
@@ -100,7 +94,8 @@ export default {
       slidePosition: 0,
       prevIndex: 0,
       offsetSlides: 0,
-      handleInterval: null
+      handleInterval: null,
+      loadedImages: [0, 1]
     }
   },
   watch: {
@@ -113,7 +108,16 @@ export default {
   },
   computed: {
     virtualImages() {
-      return [...this.images, this.images[0]]
+      let images = this.images.map((item, index) => {
+        let images = this.loadedImages.includes(index)
+          ? item
+          : {
+              ...item,
+              image: this.placeholderImage
+            }
+        return images
+      })
+      return [...images, images[0]]
     },
     hasSlideNavigation() {
       return this.images.length > 1
@@ -127,6 +131,15 @@ export default {
         this.animationRateHandler = window.requestAnimationFrame(
           this.slideAnimation
         )
+        const totalImages = this.images.length -1
+        this.addIndexToLoadedImages(index)
+        this.addIndexToLoadedImages(index === 0 ? totalImages : index - 1)
+        this.addIndexToLoadedImages(index === totalImages ? 0 : index + 1)
+      }
+    },
+    addIndexToLoadedImages(index) {
+      if (!this.loadedImages.includes(index)) {
+        this.loadedImages.push(index)
       }
     },
     nextSlide() {
@@ -136,6 +149,9 @@ export default {
       ) {
         this.prevIndex = this.currentIndex
         ++this.currentIndex
+        this.addIndexToLoadedImages(
+          this.currentIndex < this.images.length - 1 ? this.currentIndex + 1 : 0
+        )
         this.animationRateHandler = window.requestAnimationFrame(
           this.slideAnimation
         )
@@ -149,6 +165,11 @@ export default {
         }
         this.prevIndex = this.currentIndex
         --this.currentIndex
+        this.addIndexToLoadedImages(
+          this.currentIndex === 0
+            ? this.images.length - 1
+            : this.currentIndex - 1
+        )
         this.animationRateHandler = window.requestAnimationFrame(
           this.slideAnimation
         )
@@ -190,6 +211,9 @@ export default {
     },
     handleImpression(image) {
       this.$emit('on-child-impression', image.id)
+    },
+    setErrorImage(ev) {
+      ev.target.src = this.errorImage
     }
   },
   mounted() {
@@ -198,6 +222,7 @@ export default {
     if (!!this.autoplayTime && this.images.length > 1) {
       this.handleInterval = setTimeout(this.nextSlide, this.autoplayTime)
     }
+    this.addIndexToLoadedImages(this.images.length - 1)
   },
   beforeDestroy() {
     window.removeEventListener('resize', this.resizeSlideshow)

--- a/stories/nc-slideshow-v2.stories.js
+++ b/stories/nc-slideshow-v2.stories.js
@@ -5,19 +5,30 @@ import NcSlideshow from '../src/components/nc-slideshow-v2'
 const imagesMock = [
   {
     url: 'https://google.com',
-    image: 'https://www.etsan.at/wp-content/uploads/2016/01/about-cover-1.jpg',
+    image: 'https://s3.eu-west-1.amazonaws.com/cms-prod.billionhands.com/images/desktop_Billionhands_bluelow_moda_complementos_069ce5bcb3.png',
     alt: 'test'
   },
   {
     url: 'https://marca.es',
     image:
-      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSLG8Rr0SqCN8hSAj_5BBxycxxgP9tWi5SYiGoc-pYbH-29U1o&s',
+      'https://s3.eu-west-1.amazonaws.com/cms-prod.billionhands.com/images/Desktop_vichi_belleza_beauty_tendencias_c47c665bd0.jpg',
     alt: 'test 2'
   },
   {
     url: 'https://marca.es',
     image:
-      'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQJKIuBZMyH7oxEyduYDwZIJLca5pY4OZ6qNc2ZnKpTt0LJtZc&s',
+      'https://s3.eu-west-1.amazonaws.com/cms-prod.billionhands.com/images/Desktop_Hawkers_billionhands_moda_complementos_gafas_ca89b92216.jpg',
+    alt: 'test 3'
+  },
+  {
+    url: 'https://marca.es',
+    image:
+      'https://s3.eu-west-1.amazonaws.com/cms-prod.billionhands.com/images/Desktop_sarenza_moda_complementos_billionhands_d5fd700670.jpg',
+    alt: 'test 3'
+  },
+  {
+    url: 'https://marca.es',
+    image: 'https://s3.eu-west-1.amazonaws.com/cms-prod.billionhands.com/images/MIX_DESCARGA_LA_APP_1504x250_Desktop_XL_f10cb4f63a.jpg',
     alt: 'test 3'
   }
 ]


### PR DESCRIPTION
- Remove nc-lazy-image from nc-slideshow-v2
- Add error method to display error image
- Modify virtualImages to load default image o real image depending on an array of image index
- Add new method to add newIndex in image loaded index array
- use goToIndex, nextSlide and prevSlide to add next image index

- Add plugins in storybook to avoid error in stories
Related with https://nextchance.atlassian.net/browse/BH-5757